### PR TITLE
Consolidate version

### DIFF
--- a/samples/Freya/Freya.csproj
+++ b/samples/Freya/Freya.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Freya/Freya.csproj
+++ b/samples/Freya/Freya.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="Discord.Net.Rest" Version="3.9.0" />
     <PackageReference Include="Discord.Net.Webhook" Version="3.9.0" />
     <PackageReference Include="Discord.Net.WebSocket" Version="3.9.0" />
-    <PackageReference Include="mauve" Version="2023.0.0.1" />
+    <PackageReference Include="Mauve" Version="2023.0.0.3" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />

--- a/src/Glitter.Commands.OpenSource/Glitter.Commands.OpenSource.csproj
+++ b/src/Glitter.Commands.OpenSource/Glitter.Commands.OpenSource.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Glitter.Discord/Glitter.Discord.csproj
+++ b/src/Glitter.Discord/Glitter.Discord.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Glitter.Discord/Glitter.Discord.csproj
+++ b/src/Glitter.Discord/Glitter.Discord.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.9.0" />
-    <PackageReference Include="mauve" Version="2023.0.0.1" />
+    <PackageReference Include="Mauve" Version="2023.0.0.3" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
   </ItemGroup>

--- a/src/Glitter/Glitter.csproj
+++ b/src/Glitter/Glitter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Glitter/Glitter.csproj
+++ b/src/Glitter/Glitter.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mauve" Version="2023.0.0.1" />
+    <PackageReference Include="Mauve" Version="2023.0.0.3" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />

--- a/test/Glitter.Tests/Glitter.Tests.csproj
+++ b/test/Glitter.Tests/Glitter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/Glitter.Tests/Glitter.Tests.csproj
+++ b/test/Glitter.Tests/Glitter.Tests.csproj
@@ -11,12 +11,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="FluentValidation" Version="11.4.0" />
-    <PackageReference Include="Mauve" Version="2023.0.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Mauve" Version="2023.0.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
fixes #41 
and consolidate dependencies version:
```
❯ dotnet list package --outdated

The following sources were used:
   https://api.nuget.org/v3/index.json

Project `Freya` has the following updates to its packages
   [net7.0]:
   Top-level Package                                Requested    Resolved     Latest
   > mauve                                          2023.0.0.1   2023.0.0.1   2023.0.0.3
   > Microsoft.Extensions.Configuration.Binder      7.0.1        7.0.1        7.0.2

Project `Glitter` has the following updates to its packages
   [net7.0]:
   Top-level Package                                Requested    Resolved     Latest
   > mauve                                          2023.0.0.1   2023.0.0.1   2023.0.0.3
   > Microsoft.Extensions.Configuration.Binder      7.0.1        7.0.1        7.0.2

Project `Glitter.Discord` has the following updates to its packages
   [net7.0]:
   Top-level Package      Requested    Resolved     Latest
   > mauve                2023.0.0.1   2023.0.0.1   2023.0.0.3

Project `Glitter.Tests` has the following updates to its packages
   [net7.0]:
   Top-level Package             Requested    Resolved     Latest
   > coverlet.collector          3.1.2        3.1.2        3.2.0
   > Mauve                       2023.0.0.1   2023.0.0.1   2023.0.0.3
   > Microsoft.NET.Test.Sdk      17.1.0       17.1.0       17.4.1
   > NUnit.Analyzers             3.3.0        3.3.0        3.5.0
   > NUnit3TestAdapter           4.2.1        4.2.1        4.3.1

The given project `Glitter.Commands.OpenSource` has no updates given the current sources.
```

=>
```
❯ dotnet list package --outdated

The following sources were used:
   https://api.nuget.org/v3/index.json

The given project `Freya` has no updates given the current sources.
The given project `Glitter` has no updates given the current sources.
The given project `Glitter.Discord` has no updates given the current sources.
The given project `Glitter.Tests` has no updates given the current sources.
The given project `Glitter.Commands.OpenSource` has no updates given the current sources.
```