### PR TITLE
Remove unused _id field from Command

### DIFF
--- a/src/Glitter/Commands/Command.cs
+++ b/src/Glitter/Commands/Command.cs
@@ -12,7 +12,6 @@ namespace Glitter.Commands;
 /// </summary>
 public abstract class Command
 {
-    private readonly string _id;
     /// <summary>
     /// The logger for the <see cref="Command"/>.
     /// </summary>
@@ -47,7 +46,6 @@ public abstract class Command
     /// <param name="logger"></param>
     protected Command(string key, string displayName, string description, ILogger logger)
     {
-        _id = Guid.NewGuid().GetHashCode(NumericBase.Hexadecimal);
         Key = key;
         Logger = logger;
         DisplayName = displayName;


### PR DESCRIPTION
I removed the field private _id and removed line that it gave value to variable _id