### PR TITLE
Added support for static creation of `SubstringReader` instances.

### DIFF
--- a/src/Glitter/Data/Sql/SqlConnectionInstructions.cs
+++ b/src/Glitter/Data/Sql/SqlConnectionInstructions.cs
@@ -1,7 +1,13 @@
 ﻿namespace Glitter.Data.Sql;
 
+/// <summary>
+/// Represents instructions for connecting to a SQL server.
+/// </summary>
 public class SqlConnectionInstructions
 {
+    /// <summary>
+    /// Creates a new set of connection instructions.
+    /// </summary>
     public SqlConnectionInstructions(
         string server,
         string database,

--- a/src/Glitter/Glitter.csproj
+++ b/src/Glitter/Glitter.csproj
@@ -22,6 +22,7 @@
 
     <PropertyGroup Label="PackageInformation">
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <Title>Glitter</Title>
         <Description>A simple framework for encapsulating functionality to keep implementations clean, concise, and optimized.</Description>
@@ -39,9 +40,13 @@
     </PropertyGroup>
 
     <PropertyGroup Label="VersionInformation">
-        <AssemblyVersion>2024.3.1.0</AssemblyVersion>
+        <AssemblyVersion>2024.3.1.1</AssemblyVersion>
         <Version>$(AssemblyVersion)</Version>
         <PackageReleaseNotes>
+            ## 2024.3.1.1
+            - Added static `Create` method for `SubstringReader` for improved legibility.
+            - Deprecated `SubstringReader` constructor.
+            
             ## 2024.3.1.0
             - Removed support for .NET 5.0.
             - Moved pattern abstractions.

--- a/src/Glitter/Text/SubstringReader.cs
+++ b/src/Glitter/Text/SubstringReader.cs
@@ -33,6 +33,7 @@ public sealed class SubstringReader
     /// <param name="source">The string to be used as the source.</param>
     /// <param name="options">The options to be used for the <see cref="SubstringReader"/>.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="source"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    [Obsolete("This constructor will be removed in a future release. Use SubstringReader.Create(string, SubstringReaderOptions?) instead.")]
     public SubstringReader(string source, SubstringReaderOptions? options = null)
     {
         if (string.IsNullOrWhiteSpace(source))

--- a/src/Glitter/Text/SubstringReader.cs
+++ b/src/Glitter/Text/SubstringReader.cs
@@ -51,7 +51,9 @@ public sealed class SubstringReader
     /// <param name="options">The options to be used for the <see cref="SubstringReader"/>.</param>
     /// <returns>A new <see cref="SubstringReader"/> with the specified source and options.</returns>
     public static SubstringReader Create(string source, SubstringReaderOptions? options = null) =>
+#pragma warning disable CS0618 // Type or member is obsolete
         new(source, options);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Gets the current length of the <see cref="SubstringReader"/>.

--- a/src/Glitter/Text/SubstringReader.cs
+++ b/src/Glitter/Text/SubstringReader.cs
@@ -42,6 +42,15 @@ public sealed class SubstringReader
         _options = options ?? new SubstringReaderOptions();
         _currentIndex = source.CreateClamp();
     }
+    
+    /// <summary>
+    /// Creates a new <see cref="SubstringReader"/> with the specified source and options.
+    /// </summary>
+    /// <param name="source">The string to be used as the source.</param>
+    /// <param name="options">The options to be used for the <see cref="SubstringReader"/>.</param>
+    /// <returns>A new <see cref="SubstringReader"/> with the specified source and options.</returns>
+    public static SubstringReader Create(string source, SubstringReaderOptions? options = null) =>
+        new(source, options);
 
     /// <summary>
     /// Gets the current length of the <see cref="SubstringReader"/>.

--- a/src/Glitter/Text/TrimInstruction.cs
+++ b/src/Glitter/Text/TrimInstruction.cs
@@ -32,6 +32,9 @@ public class TrimInstruction
         Values = values;
     }
 
+    /// <summary>
+    /// Gets or sets the orientation of the trim.
+    /// </summary>
     public TrimOrientation Orientation { get; set; }
 
     /// <summary>


### PR DESCRIPTION
This PR introduces a static method `.Create(string, SubstringReaderOptions?)` for creating instances with improved legibility:
```cs
// Old Usage
_ = new SubstringReader(source)
    .Read(5, out string foo)
    .Read(2, out int bar)
    .ReadToEnd(out string message);

// New Usage
SubstringReader.Create(source)
    .Read(5, out string foo)
    .Read(2, out int bar)
    .ReadToEnd(out string message);
```

Additionally, this PR marks the primary constructor for `SubstringReader` as obsolete in favor of the new `Create` method.